### PR TITLE
JWT 인증 기능

### DIFF
--- a/src/main/java/com/example/mailService/MailServiceApplication.java
+++ b/src/main/java/com/example/mailService/MailServiceApplication.java
@@ -12,25 +12,28 @@ import javax.annotation.PostConstruct;
 @SpringBootApplication
 public class MailServiceApplication {
 
-	private final UserRepository repository;
+	private final UserRepository userRepository;
 
 	private final PasswordEncoder passwordEncoder;
 
-	public MailServiceApplication(UserRepository repository, PasswordEncoder passwordEncoder) {
-		this.repository = repository;
+	public MailServiceApplication(UserRepository userRepository, PasswordEncoder passwordEncoder) {
+		this.userRepository = userRepository;
 		this.passwordEncoder = passwordEncoder;
 	}
 
 	@PostConstruct
 	public void initUsers() {
-		User user = User.builder()
-				.username("admin")
-				.email("admin@social.com")
-				.password(passwordEncoder.encode("test1234"))
-				.role(UserRole.ROLE_ADMIN)
-				.build();
+		userRepository.findByUsername("admin").orElseGet(() -> {
+			User user = User.builder()
+					.username("admin")
+					.email("admin@social.com")
+					.password(passwordEncoder.encode("test1234"))
+					.role(UserRole.ROLE_ADMIN)
+					.build();
 
-		repository.save(user);
+			userRepository.save(user);
+			return user;
+		});
 	}
 
 	public static void main(String[] args) {

--- a/src/main/java/com/example/mailService/MailServiceApplication.java
+++ b/src/main/java/com/example/mailService/MailServiceApplication.java
@@ -1,6 +1,7 @@
 package com.example.mailService;
 
 import com.example.mailService.domain.entity.User;
+import com.example.mailService.domain.entity.UserRole;
 import com.example.mailService.repository.UserRepository;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
@@ -26,6 +27,7 @@ public class MailServiceApplication {
 				.username("admin")
 				.email("admin@social.com")
 				.password(passwordEncoder.encode("test1234"))
+				.role(UserRole.ROLE_ADMIN)
 				.build();
 
 		repository.save(user);

--- a/src/main/java/com/example/mailService/config/JwtFilterAdapterConfig.java
+++ b/src/main/java/com/example/mailService/config/JwtFilterAdapterConfig.java
@@ -1,0 +1,21 @@
+package com.example.mailService.config;
+
+import com.example.mailService.security.JwtTokenFilter;
+import com.example.mailService.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.config.annotation.SecurityConfigurerAdapter;
+import org.springframework.security.config.annotation.web.builders.HttpSecurity;
+import org.springframework.security.web.DefaultSecurityFilterChain;
+import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
+
+@RequiredArgsConstructor
+public class JwtFilterAdapterConfig extends SecurityConfigurerAdapter<DefaultSecurityFilterChain, HttpSecurity> {
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    @Override
+    public void configure(HttpSecurity builder) throws Exception {
+        JwtTokenFilter jwtTokenFilter = new JwtTokenFilter(jwtTokenProvider);
+        builder.addFilterBefore(jwtTokenFilter, UsernamePasswordAuthenticationFilter.class);
+    }
+}

--- a/src/main/java/com/example/mailService/config/SecurityConfig.java
+++ b/src/main/java/com/example/mailService/config/SecurityConfig.java
@@ -6,17 +6,12 @@ import com.example.mailService.security.JwtTokenProvider;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
 import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configuration.WebSecurityCustomizer;
 import org.springframework.security.config.http.SessionCreationPolicy;
-import org.springframework.security.core.userdetails.User;
-import org.springframework.security.core.userdetails.UserDetailsService;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
 @RequiredArgsConstructor

--- a/src/main/java/com/example/mailService/config/SecurityConfig.java
+++ b/src/main/java/com/example/mailService/config/SecurityConfig.java
@@ -1,8 +1,13 @@
 package com.example.mailService.config;
 
+import com.example.mailService.security.JwtAccessDeniedHandler;
+import com.example.mailService.security.JwtAuthenticationEntrypoint;
+import com.example.mailService.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.config.annotation.authentication.builders.AuthenticationManagerBuilder;
+import org.springframework.security.config.annotation.authentication.configuration.AuthenticationConfiguration;
 import org.springframework.security.config.annotation.method.configuration.EnableGlobalMethodSecurity;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
@@ -14,9 +19,14 @@ import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.security.provisioning.InMemoryUserDetailsManager;
 import org.springframework.security.web.SecurityFilterChain;
 
+@RequiredArgsConstructor
 @EnableWebSecurity
 @EnableGlobalMethodSecurity(prePostEnabled = true, securedEnabled = true, jsr250Enabled = true)
 public class SecurityConfig {
+
+    private final JwtTokenProvider jwtTokenProvider;
+    private final JwtAuthenticationEntrypoint jwtAuthenticationEntrypoint;
+    private final JwtAccessDeniedHandler jwtAccessDeniedHandler;
 
     @Bean
     public BCryptPasswordEncoder passwordEncoder() {
@@ -24,26 +34,10 @@ public class SecurityConfig {
     }
 
     @Bean
-    public UserDetailsService userDetailsService(BCryptPasswordEncoder passwordEncoder) {
-        InMemoryUserDetailsManager manager = new InMemoryUserDetailsManager();
-        manager.createUser(User.withUsername("admin")
-                .password(passwordEncoder.encode("test1234"))
-                .roles("USER", "ADMIN")
-                .build()
-        );
-        return manager;
-    }
-
-    @Bean
     public AuthenticationManager authenticationManager(
-            HttpSecurity http,
-            BCryptPasswordEncoder passwordEncoder,
-            UserDetailsService userDetailsService) throws Exception {
-        return http.getSharedObject(AuthenticationManagerBuilder.class)
-                .userDetailsService(userDetailsService)
-                .passwordEncoder(passwordEncoder)
-                .and()
-                .build();
+            AuthenticationConfiguration authenticationConfiguration
+    ) throws Exception {
+        return authenticationConfiguration.getAuthenticationManager();
     }
 
     @Bean
@@ -59,30 +53,41 @@ public class SecurityConfig {
                 .formLogin()
                 .disable()  // Form 로그인 미사용
                 .httpBasic()
-                .disable()  // HTTP basic auth(브라우저기반) 미사용
+                .disable();  // HTTP basic auth(브라우저기반) 미사용
+
+        http
                 .authorizeRequests()
-                .antMatchers("/",
-                        "/error")
-                .permitAll()
-                .antMatchers("/auth/**")
+                .antMatchers(
+                        "/",
+                        "/error",
+                        "/auth/**")
                 .permitAll()    // auth, Oauth, 기타 asset 은 인증없이 접근허용
-                .anyRequest()
-                .authenticated();    // 그 외 요청은 인증필요
+                .anyRequest().authenticated();    // 그 외 요청은 인증필요
+
+        // add JWT entrypoint & handler
+        http
+                .exceptionHandling()
+                .accessDeniedHandler(jwtAccessDeniedHandler)
+                .authenticationEntryPoint(jwtAuthenticationEntrypoint);
+
+        // add JWT adapter configuration before UsernamePasswordAuthenticationFilter
+        http.apply(new JwtFilterAdapterConfig(jwtTokenProvider));
+
         return http.build();
     }
 
-    @Bean
-    public WebSecurityCustomizer webSecurityCustomizer() {
-        return (web) -> web
-                .ignoring()
-                .antMatchers(
-                        "/favicon.ico",
-                        "/**/*.png",
-                        "/**/*.gif",
-                        "/**/*.svg",
-                        "/**/*.jpg",
-                        "/**/*.html",
-                        "/**/*.css",
-                        "/**/*.js");
-    }
+//    @Bean
+//    public WebSecurityCustomizer webSecurityCustomizer() {
+//        return (web) -> web
+//                .ignoring()
+//                .antMatchers(
+//                        "/favicon.ico",
+//                        "/**/*.png",
+//                        "/**/*.gif",
+//                        "/**/*.svg",
+//                        "/**/*.jpg",
+//                        "/**/*.html",
+//                        "/**/*.css",
+//                        "/**/*.js");
+//    }
 }

--- a/src/main/java/com/example/mailService/controller/AuthController.java
+++ b/src/main/java/com/example/mailService/controller/AuthController.java
@@ -29,7 +29,7 @@ public class AuthController {
 
         Authentication authentication = authenticationManager.authenticate(
                 new UsernamePasswordAuthenticationToken(
-                        loginDto.getEmail(),
+                        loginDto.getUsername(),
                         loginDto.getPassword()
                 )
         );

--- a/src/main/java/com/example/mailService/controller/AuthController.java
+++ b/src/main/java/com/example/mailService/controller/AuthController.java
@@ -1,47 +1,46 @@
 package com.example.mailService.controller;
 
+import com.example.mailService.domain.dto.JwtTokenDto;
 import com.example.mailService.domain.dto.UserDto;
 import com.example.mailService.domain.dto.UserLoginDto;
 import com.example.mailService.domain.dto.UserSignUpDto;
 import com.example.mailService.domain.entity.User;
+import com.example.mailService.service.AuthService;
 import com.example.mailService.service.UserService;
 import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
-import org.springframework.security.authentication.AuthenticationManager;
-import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
-import org.springframework.security.core.Authentication;
-import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.web.bind.annotation.*;
 
 import javax.validation.Valid;
+import java.util.Objects;
 
 @RequiredArgsConstructor
 @RestController
 @RequestMapping("/auth")
 public class AuthController {
 
-    private final AuthenticationManager authenticationManager;
-
-    private final UserService userService;
+    private final AuthService authService;
 
     @PostMapping("/login")
     public ResponseEntity<?> userLogin(@Valid @RequestBody UserLoginDto loginDto) {
+        JwtTokenDto tokenDto = authService.loginUser(loginDto);
 
-        Authentication authentication = authenticationManager.authenticate(
-                new UsernamePasswordAuthenticationToken(
-                        loginDto.getUsername(),
-                        loginDto.getPassword()
-                )
-        );
+        if (Objects.isNull(tokenDto)) {
+            return new ResponseEntity<>(HttpStatus.NOT_FOUND);
+        }
 
-        SecurityContextHolder.getContext().setAuthentication(authentication);
-        // TODO: add tokenGeneration before response
-        return ResponseEntity.ok(null);
+        // Authorization header 에 JWT 토큰 설정
+        HttpHeaders headers = new HttpHeaders();
+        headers.add("Authorization", "Bearer " + tokenDto.getToken());
+
+        return new ResponseEntity<>(tokenDto, headers, HttpStatus.OK);
     }
 
     @PostMapping("/signup")
     public UserDto userSignUp(@Valid @RequestBody UserSignUpDto signUpDto) {
-        User user = userService.registerUser(signUpDto);
+        User user = authService.registerUser(signUpDto);
         return UserDto.from(user);
     }
 }

--- a/src/main/java/com/example/mailService/controller/AuthController.java
+++ b/src/main/java/com/example/mailService/controller/AuthController.java
@@ -6,7 +6,6 @@ import com.example.mailService.domain.dto.UserLoginDto;
 import com.example.mailService.domain.dto.UserSignUpDto;
 import com.example.mailService.domain.entity.User;
 import com.example.mailService.service.AuthService;
-import com.example.mailService.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpHeaders;
 import org.springframework.http.HttpStatus;

--- a/src/main/java/com/example/mailService/controller/UserController.java
+++ b/src/main/java/com/example/mailService/controller/UserController.java
@@ -4,9 +4,7 @@ import com.example.mailService.domain.dto.UserDto;
 import com.example.mailService.domain.entity.User;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
-import org.springframework.stereotype.Controller;
 import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.PostMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
 

--- a/src/main/java/com/example/mailService/controller/UserController.java
+++ b/src/main/java/com/example/mailService/controller/UserController.java
@@ -2,8 +2,10 @@ package com.example.mailService.controller;
 
 import com.example.mailService.domain.dto.UserDto;
 import com.example.mailService.domain.entity.User;
+import com.example.mailService.service.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.core.userdetails.UserDetails;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestMapping;
 import org.springframework.web.bind.annotation.RestController;
@@ -13,10 +15,14 @@ import org.springframework.web.bind.annotation.RestController;
 @RequestMapping("/users")
 public class UserController {
 
+    private final UserService userService;
+
     @GetMapping("/self")
     public UserDto userSelfDetail() {
         // TODO: SecurityContextHolder 에서 유저 정보 조회
-        User user = (User) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        // https://docs.spring.io/spring-security/site/docs/4.2.x/reference/html/test-method.html
+        UserDetails userDetails = (UserDetails) SecurityContextHolder.getContext().getAuthentication().getPrincipal();
+        User user = userService.loadUserByUsername(userDetails.getUsername());
         return UserDto.from(user);
     }
 }

--- a/src/main/java/com/example/mailService/domain/dto/JwtTokenDto.java
+++ b/src/main/java/com/example/mailService/domain/dto/JwtTokenDto.java
@@ -1,0 +1,11 @@
+package com.example.mailService.domain.dto;
+
+
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+@Builder
+public class JwtTokenDto {
+    private String token;
+}

--- a/src/main/java/com/example/mailService/domain/dto/UserLoginDto.java
+++ b/src/main/java/com/example/mailService/domain/dto/UserLoginDto.java
@@ -9,7 +9,7 @@ import lombok.Getter;
 @AllArgsConstructor
 public class UserLoginDto {
 
-    private String email;
+    private String username;
 
     private String password;
 }

--- a/src/main/java/com/example/mailService/domain/entity/User.java
+++ b/src/main/java/com/example/mailService/domain/entity/User.java
@@ -11,6 +11,7 @@ import java.util.List;
 @Getter
 @Builder
 @AllArgsConstructor
+@NoArgsConstructor
 @Entity
 public class User {
 

--- a/src/main/java/com/example/mailService/domain/entity/User.java
+++ b/src/main/java/com/example/mailService/domain/entity/User.java
@@ -6,7 +6,6 @@ import lombok.Getter;
 import lombok.NoArgsConstructor;
 
 import javax.persistence.*;
-import java.util.List;
 
 @Getter
 @Builder

--- a/src/main/java/com/example/mailService/domain/entity/User.java
+++ b/src/main/java/com/example/mailService/domain/entity/User.java
@@ -29,5 +29,5 @@ public class User {
     private String password;
 
     @Enumerated(EnumType.STRING)
-    private UserRole role;
+    private UserRole role = UserRole.ROLE_USER;
 }

--- a/src/main/java/com/example/mailService/domain/entity/UserRole.java
+++ b/src/main/java/com/example/mailService/domain/entity/UserRole.java
@@ -1,5 +1,12 @@
 package com.example.mailService.domain.entity;
 
-public enum UserRole {
-    ROLE_ADMIN, ROLE_USER
+import org.springframework.security.core.GrantedAuthority;
+
+public enum UserRole implements GrantedAuthority {
+    ROLE_ADMIN, ROLE_USER;
+
+    @Override
+    public String getAuthority() {
+        return name();
+    }
 }

--- a/src/main/java/com/example/mailService/repository/UserRepository.java
+++ b/src/main/java/com/example/mailService/repository/UserRepository.java
@@ -8,4 +8,6 @@ import java.util.Optional;
 public interface UserRepository extends JpaRepository<User, Long> {
 
     Optional<User> findByEmail(String email);
+
+    Optional<User> findByUsername(String username);
 }

--- a/src/main/java/com/example/mailService/security/JwtAccessDeniedHandler.java
+++ b/src/main/java/com/example/mailService/security/JwtAccessDeniedHandler.java
@@ -1,0 +1,18 @@
+package com.example.mailService.security;
+
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.web.access.AccessDeniedHandler;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Component
+public class JwtAccessDeniedHandler implements AccessDeniedHandler {
+    @Override
+    public void handle(HttpServletRequest request, HttpServletResponse response, AccessDeniedException accessDeniedException) throws IOException, ServletException {
+        response.sendError(HttpServletResponse.SC_FORBIDDEN);
+    }
+}

--- a/src/main/java/com/example/mailService/security/JwtAuthenticationEntrypoint.java
+++ b/src/main/java/com/example/mailService/security/JwtAuthenticationEntrypoint.java
@@ -1,0 +1,23 @@
+package com.example.mailService.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.web.AuthenticationEntryPoint;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+@Component
+public class JwtAuthenticationEntrypoint implements AuthenticationEntryPoint {
+
+    @Override
+    public void commence(HttpServletRequest request, HttpServletResponse response, AuthenticationException authException) throws IOException, ServletException {
+        log.error("Responding with unauthorized error. Message: {}", authException.getMessage());
+        response.sendError(HttpServletResponse.SC_UNAUTHORIZED,
+                authException.getLocalizedMessage());
+    }
+}

--- a/src/main/java/com/example/mailService/security/JwtTokenFilter.java
+++ b/src/main/java/com/example/mailService/security/JwtTokenFilter.java
@@ -15,7 +15,7 @@ import java.io.IOException;
 @Slf4j
 public class JwtTokenFilter extends OncePerRequestFilter {
 
-    private JwtTokenProvider jwtTokenProvider;
+    private final JwtTokenProvider jwtTokenProvider;
 
     public JwtTokenFilter(JwtTokenProvider jwtTokenProvider) {
         this.jwtTokenProvider = jwtTokenProvider;

--- a/src/main/java/com/example/mailService/security/JwtTokenFilter.java
+++ b/src/main/java/com/example/mailService/security/JwtTokenFilter.java
@@ -1,0 +1,39 @@
+package com.example.mailService.security;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.util.StringUtils;
+import org.springframework.web.filter.OncePerRequestFilter;
+
+import javax.servlet.FilterChain;
+import javax.servlet.ServletException;
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletResponse;
+import java.io.IOException;
+
+@Slf4j
+public class JwtTokenFilter extends OncePerRequestFilter {
+
+    private JwtTokenProvider jwtTokenProvider;
+
+    public JwtTokenFilter(JwtTokenProvider jwtTokenProvider) {
+        this.jwtTokenProvider = jwtTokenProvider;
+    }
+
+    @Override
+    protected void doFilterInternal(HttpServletRequest request, HttpServletResponse response, FilterChain filterChain) throws ServletException, IOException {
+        try {
+            String jwtToken = jwtTokenProvider.resolveTokenFromRequest(request);
+
+            if (StringUtils.hasText(jwtToken) && jwtTokenProvider.validateToken(jwtToken)) {
+                Authentication authentication = jwtTokenProvider.getAuthenticationByToken(jwtToken);
+                SecurityContextHolder.getContext().setAuthentication(authentication);
+            }
+        } catch (Exception e) {
+            SecurityContextHolder.clearContext();
+            log.error("User Authentication error in security context: " + e);
+        }
+        filterChain.doFilter(request, response);
+    }
+}

--- a/src/main/java/com/example/mailService/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/mailService/security/JwtTokenProvider.java
@@ -1,6 +1,5 @@
 package com.example.mailService.security;
 
-import com.example.mailService.domain.entity.User;
 import io.jsonwebtoken.*;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Autowired;

--- a/src/main/java/com/example/mailService/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/mailService/security/JwtTokenProvider.java
@@ -1,0 +1,81 @@
+package com.example.mailService.security;
+
+import com.example.mailService.domain.entity.User;
+import io.jsonwebtoken.*;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
+
+import javax.servlet.http.HttpServletRequest;
+import java.util.Date;
+
+@Slf4j
+@Component
+public class JwtTokenProvider {
+
+    @Value("${authentication.secret-key}")
+    private String secretKey;
+
+    @Value("${authentication.expiration-time}")
+    private Long expirationMilliSec;
+
+    @Autowired
+    private UserDetailsService userDetailsService;
+
+
+    public String generateToken(Authentication authentication) {
+        User user = (User) authentication.getPrincipal();
+        Claims claims = Jwts.claims().setSubject(user.getUsername());
+
+        Date now = new Date();
+        Date expirationDate = new Date(now.getTime() + expirationMilliSec);
+
+        return Jwts.builder()
+                .setClaims(claims)
+                .setIssuedAt(now)
+                .setExpiration(expirationDate)
+                .signWith(SignatureAlgorithm.HS512, secretKey)
+                .compact();
+    }
+
+    public Authentication getAuthenticationByToken(String token) {
+        UserDetails user = userDetailsService.loadUserByUsername(getUsernameByToken(token));
+        return new UsernamePasswordAuthenticationToken(user, "", user.getAuthorities());
+    }
+
+    public String getUsernameByToken(String token) {
+        return Jwts.parser().setSigningKey(secretKey).parseClaimsJws(token).getBody().getSubject();
+    }
+
+    public String resolveTokenFromRequest(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7, bearerToken.length());
+        } else return null;
+    }
+
+    public boolean validateToken(String token) {
+        try {
+            Jwts.parser().setSigningKey(secretKey)
+                    .parseClaimsJws(token);
+            return true;
+        } catch (SignatureException exception) {
+            log.error("Invalid JWT signature");
+        } catch (MalformedJwtException exception) {
+            log.error("Invalid JWT Token");
+        } catch (ExpiredJwtException exception) {
+            log.error("Expired JWT Token");
+        } catch (UnsupportedJwtException exception) {
+            log.error("Unsupported JWT token");
+        } catch (IllegalArgumentException exception) {
+            log.error("JWT claims is empty");
+        }
+        return false;
+    }
+}

--- a/src/main/java/com/example/mailService/security/JwtTokenProvider.java
+++ b/src/main/java/com/example/mailService/security/JwtTokenProvider.java
@@ -30,8 +30,7 @@ public class JwtTokenProvider {
 
 
     public String generateToken(Authentication authentication) {
-        User user = (User) authentication.getPrincipal();
-        Claims claims = Jwts.claims().setSubject(user.getUsername());
+        Claims claims = Jwts.claims().setSubject(authentication.getName());
 
         Date now = new Date();
         Date expirationDate = new Date(now.getTime() + expirationMilliSec);

--- a/src/main/java/com/example/mailService/security/UserDetailsServiceImpl.java
+++ b/src/main/java/com/example/mailService/security/UserDetailsServiceImpl.java
@@ -1,0 +1,34 @@
+package com.example.mailService.security;
+
+import com.example.mailService.domain.entity.User;
+import com.example.mailService.repository.UserRepository;
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.security.core.userdetails.UserDetailsService;
+import org.springframework.security.core.userdetails.UsernameNotFoundException;
+import org.springframework.stereotype.Service;
+
+@Service
+@RequiredArgsConstructor
+public class UserDetailsServiceImpl implements UserDetailsService {
+    // 서비스 User 정보를 Spring Security 의 UserDetails 로 감싸
+    // 인증/인가를 위한 Service
+
+    private final UserRepository userRepository;
+
+    @Override
+    public UserDetails loadUserByUsername(String username) throws UsernameNotFoundException {
+        final User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+
+        return org.springframework.security.core.userdetails.User
+                .withUsername(username)
+                .password(user.getPassword())
+                .authorities(user.getRole())
+                .accountExpired(false)
+                .accountLocked(false)
+                .credentialsExpired(false)
+                .disabled(false)
+                .build();
+    }
+}

--- a/src/main/java/com/example/mailService/service/AuthService.java
+++ b/src/main/java/com/example/mailService/service/AuthService.java
@@ -16,12 +16,14 @@ import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.core.context.SecurityContextHolder;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Slf4j
 @RequiredArgsConstructor
 @Service
+@Transactional(readOnly = true)
 public class AuthService {
 
     private final AuthenticationManager authenticationManager;
@@ -50,6 +52,7 @@ public class AuthService {
         } return null;
     }
 
+    @Transactional(readOnly = false)
     public User registerUser(UserSignUpDto signUpDto) throws UserAlreadyExistsException {
 
         Optional<User> existingUser = userRepository.findByEmail(signUpDto.getEmail());

--- a/src/main/java/com/example/mailService/service/AuthService.java
+++ b/src/main/java/com/example/mailService/service/AuthService.java
@@ -1,0 +1,70 @@
+package com.example.mailService.service;
+
+import com.example.mailService.domain.dto.JwtTokenDto;
+import com.example.mailService.domain.dto.UserLoginDto;
+import com.example.mailService.domain.dto.UserSignUpDto;
+import com.example.mailService.domain.entity.User;
+import com.example.mailService.exception.UserAlreadyExistsException;
+import com.example.mailService.repository.UserRepository;
+import com.example.mailService.security.JwtTokenProvider;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.core.context.SecurityContextHolder;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.stereotype.Service;
+
+import java.util.Optional;
+
+@Slf4j
+@RequiredArgsConstructor
+@Service
+public class AuthService {
+
+    private final AuthenticationManager authenticationManager;
+    private final UserRepository userRepository;
+
+    private final JwtTokenProvider jwtTokenProvider;
+
+    public JwtTokenDto loginUser(UserLoginDto loginDto) {
+        try {
+            Authentication authentication = authenticationManager.authenticate(
+                    new UsernamePasswordAuthenticationToken(
+                            loginDto.getUsername(),
+                            loginDto.getPassword()
+                    )
+            );
+            SecurityContextHolder.getContext().setAuthentication(authentication);
+
+            // JWT token 발급
+            String jwtToken = jwtTokenProvider.generateToken(authentication);
+            return JwtTokenDto.builder()
+                    .token(jwtToken)
+                    .build();
+
+        } catch (AuthenticationException e) {
+            log.warn("User Authentication fail: loginDTO {} | {}", loginDto, e.getMessage());
+        } return null;
+    }
+
+    public User registerUser(UserSignUpDto signUpDto) throws UserAlreadyExistsException {
+
+        Optional<User> existingUser = userRepository.findByEmail(signUpDto.getEmail());
+        if (existingUser.isPresent()) {
+            throw new UserAlreadyExistsException("User already exists with email: " + signUpDto.getEmail());
+        } else {
+            BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+            User newUser = User.builder()
+                    .username(signUpDto.getUsername())
+                    .email(signUpDto.getEmail())
+                    .password(passwordEncoder.encode(signUpDto.getPassword()))
+                    .build();
+
+            return userRepository.save(newUser);
+        }
+    }
+}

--- a/src/main/java/com/example/mailService/service/UserService.java
+++ b/src/main/java/com/example/mailService/service/UserService.java
@@ -25,6 +25,11 @@ public class UserService {
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with email: " + email));
     }
 
+    public User loadUserByUsername(String username) throws UsernameNotFoundException {
+        return userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("User not found with username: " + username));
+    }
+
     public User loadUserById(Long id) throws UsernameNotFoundException {
         return userRepository.findById(id)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + id));

--- a/src/main/java/com/example/mailService/service/UserService.java
+++ b/src/main/java/com/example/mailService/service/UserService.java
@@ -34,21 +34,4 @@ public class UserService {
         return userRepository.findById(id)
                 .orElseThrow(() -> new UsernameNotFoundException("User not found with id: " + id));
     }
-
-    public User registerUser(UserSignUpDto signUpDto) throws UserAlreadyExistsException {
-        Optional<User> existingUser = userRepository.findByEmail(signUpDto.getEmail());
-        if (existingUser.isPresent()) {
-            throw new UserAlreadyExistsException("User already exists with email: " + signUpDto.getEmail());
-        } else {
-            BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
-
-            User newUser = User.builder()
-                    .username(signUpDto.getUsername())
-                    .email(signUpDto.getEmail())
-                    .password(passwordEncoder.encode(signUpDto.getPassword()))
-                    .build();
-
-            return userRepository.save(newUser);
-        }
-    }
 }

--- a/src/main/java/com/example/mailService/service/UserService.java
+++ b/src/main/java/com/example/mailService/service/UserService.java
@@ -8,10 +8,12 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import java.util.Optional;
 
 @Service
+@Transactional(readOnly = true)
 public class UserService {
 
     private final UserRepository userRepository;

--- a/src/main/java/com/example/mailService/service/UserService.java
+++ b/src/main/java/com/example/mailService/service/UserService.java
@@ -1,16 +1,10 @@
 package com.example.mailService.service;
 
-import com.example.mailService.domain.dto.UserSignUpDto;
 import com.example.mailService.domain.entity.User;
-import com.example.mailService.exception.UserAlreadyExistsException;
 import com.example.mailService.repository.UserRepository;
-import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
-
-import java.util.Optional;
 
 @Service
 @Transactional(readOnly = true)

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
     generate-ddl: true
     show-sql: true

--- a/src/test/java/com/example/mailService/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/mailService/controller/AuthControllerTest.java
@@ -1,14 +1,19 @@
 package com.example.mailService.controller;
 
+import com.example.mailService.domain.dto.UserDto;
+import com.example.mailService.domain.dto.UserLoginDto;
+import com.example.mailService.domain.dto.UserSignUpDto;
 import com.example.mailService.domain.entity.User;
+import com.example.mailService.domain.entity.UserRole;
+import com.example.mailService.exception.UserAlreadyExistsException;
 import com.example.mailService.repository.UserRepository;
-import com.example.mailService.security.JwtTokenProvider;
-import com.example.mailService.service.AuthService;
-import com.example.mailService.service.UserService;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 
@@ -17,23 +22,107 @@ import static org.junit.jupiter.api.Assertions.*;
 @SpringBootTest
 @Transactional
 class AuthControllerTest {
-    private static UserService userService;
+
+    @Autowired
+    private AuthController authController;
 
     @Autowired
     private UserRepository userRepository;
+
+    private final String USERNAME = "testUser";
+    private final String EMAIL = "test@test.com";
+    private final String PASSWORD = "test1234";
+
+    private UserLoginDto testUserLoginDto() {
+        return UserLoginDto.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .build();
+    }
+
+    private UserLoginDto testUserLoginDto(String username) {
+        return UserLoginDto.builder()
+                .username(username)
+                .password(PASSWORD)
+                .build();
+    }
+
+    private UserSignUpDto testUserSignUpDto() {
+        return UserSignUpDto.builder()
+                .username(USERNAME)
+                .email(EMAIL)
+                .password(PASSWORD)
+                .build();
+    }
+
+    private UserSignUpDto testUserSignUpDto(String username, String email) {
+        return UserSignUpDto.builder()
+                .username(username)
+                .email(email)
+                .password(PASSWORD)
+                .build();
+    }
 
     @BeforeEach
     private void beforeEach() {
         // TODO: @BeforeAll 와 같이 테스트 데이터 setup 을 한번으로 끝낼 수는 없을까?
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
-        userService = new UserService(userRepository);
-
         User testUser = User.builder()
-                .username("testUser")
-                .email("test@test.com")
-                .password(passwordEncoder.encode("testPassword"))
+                .username(USERNAME)
+                .email(EMAIL)
+                .password(passwordEncoder.encode(PASSWORD))
+                .role(UserRole.ROLE_USER)
                 .build();
         userRepository.save(testUser);
+    }
+
+    @Test
+    public void testAuthControllerUserLogin_SUCCESS() {
+        // given
+        UserLoginDto loginDto = testUserLoginDto();
+
+        // when
+        ResponseEntity<?> response = authController.userLogin(loginDto);
+
+        // then
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.OK);
+        Assertions.assertThat(response.getHeaders().getFirst("Authorization")).startsWith("Bearer ");
+    }
+
+    @Test
+    public void testAuthControllerUserLogin_FAIL() throws Exception {
+        // given
+        UserLoginDto loginDto = testUserLoginDto("WRONG_USER");
+
+        // when
+        ResponseEntity<?> response = authController.userLogin(loginDto);
+
+        // then
+        Assertions.assertThat(response.getStatusCode()).isEqualTo(HttpStatus.NOT_FOUND);
+    }
+
+    @Test
+    public void testAuthControllerUserSignUp_SUCCESS() {
+        // given
+        UserSignUpDto signUpDto = testUserSignUpDto("NEW_USER","new@test.com");
+
+        // when
+        UserDto userDto = authController.userSignUp(signUpDto);
+
+        // then
+        Assertions.assertThat(userDto.getUsername()).isEqualTo(signUpDto.getUsername());
+        Assertions.assertThat(userDto.getEmail()).isEqualTo(signUpDto.getEmail());
+    }
+
+    @Test
+    public void testAuthControllerUserSignUp_FAIL() throws Exception {
+        // given
+        UserSignUpDto signUpDto = testUserSignUpDto();
+
+        // when
+
+        // then
+        org.junit.jupiter.api.Assertions.assertThrows(UserAlreadyExistsException.class, () -> authController.userSignUp(signUpDto));
     }
 }

--- a/src/test/java/com/example/mailService/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/mailService/controller/AuthControllerTest.java
@@ -1,0 +1,39 @@
+package com.example.mailService.controller;
+
+import com.example.mailService.domain.entity.User;
+import com.example.mailService.repository.UserRepository;
+import com.example.mailService.security.JwtTokenProvider;
+import com.example.mailService.service.AuthService;
+import com.example.mailService.service.UserService;
+import org.junit.jupiter.api.BeforeEach;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.authentication.AuthenticationManager;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class AuthControllerTest {
+    private static UserService userService;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    @BeforeEach
+    private void beforeEach() {
+        // TODO: @BeforeAll 와 같이 테스트 데이터 setup 을 한번으로 끝낼 수는 없을까?
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        userService = new UserService(userRepository);
+
+        User testUser = User.builder()
+                .username("testUser")
+                .email("test@test.com")
+                .password(passwordEncoder.encode("testPassword"))
+                .build();
+        userRepository.save(testUser);
+    }
+}

--- a/src/test/java/com/example/mailService/controller/UserControllerTest.java
+++ b/src/test/java/com/example/mailService/controller/UserControllerTest.java
@@ -1,0 +1,59 @@
+package com.example.mailService.controller;
+
+import com.example.mailService.domain.dto.UserDto;
+import com.example.mailService.domain.entity.User;
+import com.example.mailService.domain.entity.UserRole;
+import com.example.mailService.repository.UserRepository;
+import org.assertj.core.api.Assertions;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.security.test.context.support.WithUserDetails;
+import org.springframework.transaction.annotation.Transactional;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+@Transactional
+class UserControllerTest {
+
+    @Autowired
+    private UserController userController;
+
+    @Autowired
+    private UserRepository userRepository;
+
+    private final String USERNAME = "testUser";
+    private final String EMAIL = "test@test.com";
+    private final String PASSWORD = "test1234";
+
+    @BeforeEach
+    private void beforeEach() {
+        // TODO: @BeforeAll 와 같이 테스트 데이터 setup 을 한번으로 끝낼 수는 없을까?
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        User testUser = User.builder()
+                .username(USERNAME)
+                .email(EMAIL)
+                .password(passwordEncoder.encode(PASSWORD))
+                .role(UserRole.ROLE_USER)
+                .build();
+        userRepository.save(testUser);
+    }
+
+    @Test
+    @WithMockUser(username = USERNAME, password = PASSWORD)
+    public void testUserControllerUserSelfDetail_SUCCESS() throws Exception {
+        // given
+        UserDto loginUserDto = userController.userSelfDetail();
+
+        // when
+
+        // then
+        Assertions.assertThat(loginUserDto.getUsername()).isEqualTo(USERNAME);
+        Assertions.assertThat(loginUserDto.getEmail()).isEqualTo(EMAIL);
+    }
+}

--- a/src/test/java/com/example/mailService/service/AuthServiceTest.java
+++ b/src/test/java/com/example/mailService/service/AuthServiceTest.java
@@ -1,17 +1,17 @@
 package com.example.mailService.service;
 
+import com.example.mailService.domain.dto.JwtTokenDto;
+import com.example.mailService.domain.dto.UserLoginDto;
 import com.example.mailService.domain.dto.UserSignUpDto;
 import com.example.mailService.domain.entity.User;
 import com.example.mailService.domain.entity.UserRole;
 import com.example.mailService.exception.UserAlreadyExistsException;
 import com.example.mailService.repository.UserRepository;
-import com.example.mailService.security.JwtTokenProvider;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.security.authentication.AuthenticationManager;
 import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
 import org.springframework.transaction.annotation.Transactional;
 import org.springframework.util.StringUtils;
@@ -34,6 +34,21 @@ class AuthServiceTest {
     private final String USERNAME = "testUser";
     private final String EMAIL = "test@test.com";
     private final String PASSWORD = "test1234";
+
+
+    private UserLoginDto testUserLoginDto() {
+        return UserLoginDto.builder()
+                .username(USERNAME)
+                .password(PASSWORD)
+                .build();
+    }
+
+    private UserLoginDto testUserLoginDto(String username) {
+        return UserLoginDto.builder()
+                .username(username)
+                .password(PASSWORD)
+                .build();
+    }
 
     private UserSignUpDto testUserSignUpDto() {
         return UserSignUpDto.builder()
@@ -62,6 +77,7 @@ class AuthServiceTest {
                 .username(USERNAME)
                 .email(EMAIL)
                 .password(passwordEncoder.encode(PASSWORD))
+                .role(UserRole.ROLE_USER)
                 .build();
         userRepository.save(testUser);
     }
@@ -93,5 +109,28 @@ class AuthServiceTest {
 
         // then
         Assertions.assertThrows(UserAlreadyExistsException.class, () -> authService.registerUser(duplicateSignUpDto));
+    }
+
+    @Test
+    public void UserService_loginUser_SUCCESS() throws Exception {
+        // given
+        UserLoginDto loginDto = testUserLoginDto("WRONG_USERNAME");
+
+        // when
+
+        // then
+        assertNull(authService.loginUser(loginDto));
+    }
+
+    @Test
+    public void UserService_loginUser_FAIL() throws Exception {
+        // given
+        UserLoginDto loginDto = testUserLoginDto();
+
+        // when
+        JwtTokenDto jwtToken = authService.loginUser(loginDto);
+
+        // then
+        assertTrue(StringUtils.hasText(jwtToken.getToken()));
     }
 }

--- a/src/test/java/com/example/mailService/service/AuthServiceTest.java
+++ b/src/test/java/com/example/mailService/service/AuthServiceTest.java
@@ -1,0 +1,51 @@
+package com.example.mailService.service;
+
+import com.example.mailService.domain.dto.UserSignUpDto;
+import com.example.mailService.domain.entity.User;
+import com.example.mailService.exception.UserAlreadyExistsException;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.junit.jupiter.api.Assertions.*;
+
+@SpringBootTest
+class AuthServiceTest {
+
+    @Autowired
+    private static AuthService authService;
+
+    @Test
+    public void UserService_registerUser_SUCCESS() throws Exception {
+        // given
+        UserSignUpDto signUpDto = UserSignUpDto.builder()
+                .username("signUpUser")
+                .email("signup@test.com")
+                .password("testPassword")
+                .build();
+
+        // when
+        User signUpUser = authService.registerUser(signUpDto);
+
+        // then
+        Assertions.assertEquals(signUpUser.getUsername(), signUpDto.getUsername());
+        Assertions.assertEquals(signUpUser.getEmail(), signUpDto.getEmail());
+        Assertions.assertNotEquals(signUpUser.getPassword(), signUpDto.getPassword());
+    }
+
+    @Test
+    public void UserService_registerUser_FAIL() throws Exception {
+        // given
+        UserSignUpDto duplicateSignUpDto = UserSignUpDto.builder()
+                .username("signUpUser")
+                .email("test@test.com")
+                .password("testPassword")
+                .build();
+
+        // when
+
+        // then
+        Assertions.assertThrows(UserAlreadyExistsException.class, () -> authService.registerUser(duplicateSignUpDto));
+    }
+}

--- a/src/test/java/com/example/mailService/service/UserServiceTest.java
+++ b/src/test/java/com/example/mailService/service/UserServiceTest.java
@@ -62,37 +62,4 @@ class UserServiceTest {
         Assertions.assertEquals(user.getId(), userId);
         Assertions.assertThrows(UsernameNotFoundException.class, () -> userService.loadUserById(9999999L));
     }
-
-    @Test
-    public void UserService_registerUser_SUCCESS() throws Exception {
-        // given
-        UserSignUpDto signUpDto = UserSignUpDto.builder()
-                .username("signUpUser")
-                .email("signup@test.com")
-                .password("testPassword")
-                .build();
-
-        // when
-        User signUpUser = userService.registerUser(signUpDto);
-
-        // then
-        Assertions.assertEquals(signUpUser.getUsername(), signUpDto.getUsername());
-        Assertions.assertEquals(signUpUser.getEmail(), signUpDto.getEmail());
-        Assertions.assertNotEquals(signUpUser.getPassword(), signUpDto.getPassword());
-    }
-
-    @Test
-    public void UserService_registerUser_FAIL() throws Exception {
-        // given
-        UserSignUpDto duplicateSignUpDto = UserSignUpDto.builder()
-                .username("signUpUser")
-                .email("test@test.com")
-                .password("testPassword")
-                .build();
-
-        // when
-
-        // then
-        Assertions.assertThrows(UserAlreadyExistsException.class, () -> userService.registerUser(duplicateSignUpDto));
-    }
 }

--- a/src/test/java/com/example/mailService/service/UserServiceTest.java
+++ b/src/test/java/com/example/mailService/service/UserServiceTest.java
@@ -22,6 +22,10 @@ class UserServiceTest {
     @Autowired
     private UserRepository userRepository;
 
+    private final String USERNAME = "testUser";
+    private final String EMAIL = "test@test.com";
+    private final String PASSWORD = "test1234";
+
     @BeforeEach
     private void beforeEach() {
         // TODO: @BeforeAll 와 같이 테스트 데이터 setup 을 한번으로 끝낼 수는 없을까?
@@ -29,9 +33,9 @@ class UserServiceTest {
         userService = new UserService(userRepository);
 
         User testUser = User.builder()
-                .username("testUser")
-                .email("test@test.com")
-                .password(passwordEncoder.encode("testPassword"))
+                .username(USERNAME)
+                .email(EMAIL)
+                .password(passwordEncoder.encode(PASSWORD))
                 .build();
         userRepository.save(testUser);
     }
@@ -39,21 +43,20 @@ class UserServiceTest {
     @Test
     public void UserService_loadUserByEmail() throws Exception {
         // given
-        String email = "test@test.com";
         String emailNotExists = "no@exist.com";
 
         // when
-        User user = userService.loadUserByEmail(email);
+        User user = userService.loadUserByEmail(EMAIL);
 
         // then
-        Assertions.assertEquals(user.getEmail(), email);
+        Assertions.assertEquals(user.getEmail(), EMAIL);
         Assertions.assertThrows(UsernameNotFoundException.class, () -> userService.loadUserByEmail(emailNotExists));
     }
 
     @Test
     public void UserService_loadUserById() throws Exception {
         // given
-        Long userId = userRepository.findByEmail("test@test.com").get().getId();
+        Long userId = userRepository.findByEmail(EMAIL).get().getId();
 
         // when
         User user = userService.loadUserById(userId);

--- a/src/test/java/com/example/mailService/service/UserServiceTest.java
+++ b/src/test/java/com/example/mailService/service/UserServiceTest.java
@@ -2,6 +2,7 @@ package com.example.mailService.service;
 
 import com.example.mailService.domain.dto.UserSignUpDto;
 import com.example.mailService.domain.entity.User;
+import com.example.mailService.domain.entity.UserRole;
 import com.example.mailService.exception.UserAlreadyExistsException;
 import com.example.mailService.repository.UserRepository;
 import org.junit.jupiter.api.Assertions;
@@ -36,6 +37,7 @@ class UserServiceTest {
                 .username(USERNAME)
                 .email(EMAIL)
                 .password(passwordEncoder.encode(PASSWORD))
+                .role(UserRole.ROLE_USER)
                 .build();
         userRepository.save(testUser);
     }

--- a/target/classes/application.yml
+++ b/target/classes/application.yml
@@ -7,7 +7,7 @@ spring:
 
   jpa:
     hibernate:
-      ddl-auto: create-drop
+      ddl-auto: update
 
     generate-ddl: true
     show-sql: true


### PR DESCRIPTION
Issue #13 

# 추가사항 & Issue 변경점

## Security

- TokenProvider
    - 유저 검증: id 대신 username 으로 JWT 토큰 발급/검증
    - JwtAuthenticationFilter 에서 토큰 검증을 위해 `resolveTokenFromRequest` 메서드 추가
- JwtTokenFilter
    - 각 요청마다 JWT token 확인 및 user Authentication 설정 (SecurityContextHolder)
- JwtAuthenticationEntrypoint
    - REST 에서 웹브라우저의 entry point와 동일한 역할을 수행
    - 인증(Authentication)되지 않은 유저가 요청했을 때 동작. 인증 없이 접근 가능한 URI를 제외한 모든 요청에 대해  HTTP status 401 반환 처리를 진행. [docs](https://docs.spring.io/spring-security/site/docs/current/api/org/springframework/security/web/AuthenticationEntryPoint.html)
- JwtAccessDeniedHandler
    - 인증(Authentication) 후 접근 가능한 권한을 확인 후 액세스가 불가한 요청 시 동작. (참고)[https://kim-jong-hyun.tistory.com/36]
    - 추후, Controller 별 @PreAuthorize 와 같이 인가 처리 시 필요 
- UserDetailsServiceImpl
    - 도메인 user 서비스와 별개로 Spring Security 인증/인가에서 유저정보 조회와 Authentication 설정에 쓰이는 Component

## Configuration

- JWT 인증에 대해 SecurityConfigurerAdapter 로 구성하여 SecurityConfig에 적용
- #14 에서 SpringBoot / Spring Security 버전에 맞게 각 기능을 Bean으로 등록

## Service / Controller

- User & Auth 분리
    - UserService / UserController : 유저 도메인에서 정보 조회/검색
    - AuthService / AuthController : 로그인/회원가입 등 민감정보에 대한 로직 처리

## 기타 작업

- User & Auth 로직별 테스트케이스 추가
    - UserServiceTest
    - UserControllerTest
    - AuthServiceTest
    - AuthControllerTest