### PR TITLE
Feature/mail send

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -66,11 +66,6 @@
 			<artifactId>jackson-databind</artifactId>
 			<version>2.13.3</version>
 		</dependency>
-		<dependency>
-			<groupId>org.mapstruct</groupId>
-			<artifactId>mapstruct</artifactId>
-			<version>1.5.2.Final</version>
-		</dependency>
 
 		<dependency>
 			<groupId>io.jsonwebtoken</groupId>
@@ -87,6 +82,14 @@
 			<groupId>org.springframework.boot</groupId>
 			<artifactId>spring-boot-starter-actuator</artifactId>
 			<version>2.7.0</version>
+		</dependency>
+
+		<!-- https://mvnrepository.com/artifact/org.mockito/mockito-all -->
+		<dependency>
+			<groupId>org.mockito</groupId>
+			<artifactId>mockito-all</artifactId>
+			<version>1.10.19</version>
+			<scope>test</scope>
 		</dependency>
 
 		<!-- https://mvnrepository.com/artifact/com.sun.mail/javax.mail -->

--- a/src/main/java/com/example/mailService/email/EmailMetadataService.java
+++ b/src/main/java/com/example/mailService/email/EmailMetadataService.java
@@ -25,16 +25,22 @@ public class EmailMetadataService {
 
     // 유저 메일정보 조회 / 생성
 
-    public List<EmailMetadata> loadUserEmailInfoListByUserId(Long userId) {
+    public List<EmailMetadata> loadEmailMetadataListByUserId(Long userId) {
         return userEmailInfoRepository.findAllByUser_Id(userId);
     }
 
-    public EmailMetadata loadUserEmailInfoById(Long userEmailInfoId) {
-        return userEmailInfoRepository.findById(userEmailInfoId)
-                .orElseThrow(() -> new ResourceNotFoundException("UserEmailInfo not found by id: " + userEmailInfoId));
+    public EmailMetadata loadEmailMetadataById(Long metadataId) {
+        return userEmailInfoRepository.findById(metadataId)
+                .orElseThrow(() -> new ResourceNotFoundException("EmailMetadata not found by id: " + metadataId));
     }
 
-    public EmailMetadata createUserEmailInfo(MailMetadataCreateDto createDto) {
+    public EmailMetadata loadEmailMetadataByEmailAndUserId(String email, Long userId) {
+        return userEmailInfoRepository.findByEmailAndUser_Id(email, userId)
+                .orElseThrow(() -> new ResourceNotFoundException("EmailMetadata not found by email & userId: " + email + userId));
+    }
+
+    public EmailMetadata createEmailMetadata(MailMetadataCreateDto createDto) {
+        // TODO: Java mail API 를 사용해서 유효한 메일 메타데이터 인지 검증해야함
         User requestUser = userService.loadUserFromSecurityContextHolder();
         Optional<EmailMetadata> existingUserEmailInfo = userEmailInfoRepository.findByEmailAndUser_Id(createDto.getEmail(), requestUser.getId());
         if (!existingUserEmailInfo.isPresent() & createDto.getUser().equals(requestUser)) {

--- a/src/main/java/com/example/mailService/email/EmailMetadataService.java
+++ b/src/main/java/com/example/mailService/email/EmailMetadataService.java
@@ -1,11 +1,12 @@
 package com.example.mailService.email;
 
+import com.example.mailService.email.dto.EmailCreateDto;
 import com.example.mailService.email.dto.MailMetadataCreateDto;
 import com.example.mailService.user.entity.User;
 import com.example.mailService.email.entity.EmailMetadata;
 import com.example.mailService.exception.ResourceAlreadyExistException;
 import com.example.mailService.exception.ResourceNotFoundException;
-import com.example.mailService.repository.UserEmailInfoRepository;
+import com.example.mailService.repository.EmailMetadataRepository;
 import com.example.mailService.user.UserService;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
@@ -13,40 +14,59 @@ import org.springframework.transaction.annotation.Transactional;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Properties;
 
 @Service
-@Transactional
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class EmailMetadataService {
 
-    private final UserEmailInfoRepository userEmailInfoRepository;
+    private final EmailMetadataRepository emailMetadataRepository;
 
     private final UserService userService;
 
     // 유저 메일정보 조회 / 생성
 
     public List<EmailMetadata> loadEmailMetadataListByUserId(Long userId) {
-        return userEmailInfoRepository.findAllByUser_Id(userId);
+        return emailMetadataRepository.findAllByUser_Id(userId);
     }
 
     public EmailMetadata loadEmailMetadataById(Long metadataId) {
-        return userEmailInfoRepository.findById(metadataId)
+        return emailMetadataRepository.findById(metadataId)
                 .orElseThrow(() -> new ResourceNotFoundException("EmailMetadata not found by id: " + metadataId));
     }
 
     public EmailMetadata loadEmailMetadataByEmailAndUserId(String email, Long userId) {
-        return userEmailInfoRepository.findByEmailAndUser_Id(email, userId)
+        return emailMetadataRepository.findByEmailAndUser_Id(email, userId)
                 .orElseThrow(() -> new ResourceNotFoundException("EmailMetadata not found by email & userId: " + email + userId));
     }
 
+    @Transactional(readOnly = false)
     public EmailMetadata createEmailMetadata(MailMetadataCreateDto createDto) {
         // TODO: Java mail API 를 사용해서 유효한 메일 메타데이터 인지 검증해야함
         User requestUser = userService.loadUserFromSecurityContextHolder();
-        Optional<EmailMetadata> existingUserEmailInfo = userEmailInfoRepository.findByEmailAndUser_Id(createDto.getEmail(), requestUser.getId());
+        Optional<EmailMetadata> existingUserEmailInfo = emailMetadataRepository.findByEmailAndUser_Id(createDto.getEmail(), requestUser.getId());
         if (!existingUserEmailInfo.isPresent() & createDto.getUser().equals(requestUser)) {
-            return userEmailInfoRepository.save(createDto.toEntity());
+            return emailMetadataRepository.save(createDto.toEntity());
         } else if (existingUserEmailInfo.isPresent()) {
             throw new ResourceAlreadyExistException("Resource already exist with: " + existingUserEmailInfo);
         } else throw new IllegalArgumentException("Request user is not equal. User: " + requestUser.getId() + ", Request:" + createDto.getUser().getId());
+    }
+
+    public boolean validMailMetadata(EmailCreateDto createDto) {
+        // 요청자 정보와 메일 정보 검증
+        User user = userService.loadUserFromSecurityContextHolder();
+        EmailMetadata emailMetadata = loadEmailMetadataByEmailAndUserId(createDto.getEmailFrom(), createDto.getUserId());
+        return emailMetadata.getUser().equals(user);
+    }
+
+    public Properties generateEmailMetadataProperty(EmailMetadata metadata) {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.host", metadata.getSmtpHost());
+        properties.put("mail.smtp.port", metadata.getSmtpPort());
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.smtp.ssl.enable", "true");
+        properties.put("mail.smtp.trust", metadata.getSmtpHost());
+        return properties;
     }
 }

--- a/src/main/java/com/example/mailService/email/EmailSendService.java
+++ b/src/main/java/com/example/mailService/email/EmailSendService.java
@@ -1,19 +1,101 @@
 package com.example.mailService.email;
 
-import com.example.mailService.email.EmailService;
-import com.example.mailService.utils.MailUtils;
+import com.example.mailService.email.dto.EmailCreateDto;
+import com.example.mailService.email.dto.EmailMessageDto;
+import com.example.mailService.email.entity.Email;
+import com.example.mailService.email.entity.EmailMetadata;
+import com.example.mailService.exception.ResourceNotFoundException;
+import com.example.mailService.user.UserService;
+import com.example.mailService.user.entity.User;
+import com.example.mailService.utils.MailSender;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
+import javax.mail.Message;
+import javax.mail.MessagingException;
+import javax.mail.Session;
+import javax.mail.internet.InternetAddress;
+import java.util.Optional;
+import java.util.Properties;
+
+@Slf4j
 @Service
+@Transactional(readOnly = true)
 @RequiredArgsConstructor
 public class EmailSendService {
+    // 메일 전송 서비스
+
+    private UserService userService;
 
     private EmailService emailService;
 
-    private MailUtils mailUtils;
+    private EmailMetadataService emailMetadataService;
 
-    // 메일 전송 기능
-    // 1. 유저 메일정보 조회 & 검증
-    // 2. DTO를 기반으로 메일 작성
+    private MailSender mailSender;
+
+    public MailSender generateMailSender(EmailMetadata metadata) {
+        Properties properties = new Properties();
+        properties.put("mail.smtp.host", metadata.getSmtpHost());
+        properties.put("mail.smtp.port", metadata.getSmtpPort());
+        properties.put("mail.smtp.auth", "true");
+        properties.put("mail.smtp.ssl.enable", "true");
+        properties.put("mail.smtp.trust", metadata.getSmtpHost());
+
+        return MailSender.builder()
+                .username(metadata.getUsername())
+                .password(metadata.getPassword())
+                .smtpHost(metadata.getSmtpHost())
+                .smtpPort(metadata.getSmtpPort())
+                .properties(properties)
+                .build();
+    }
+
+    public Optional<Message> generateMailSenderMessage(MailSender mailSender, EmailCreateDto createDto) {
+        try {
+            Session senderSession = mailSender.generateMailSession();
+            EmailMessageDto messageDto = createDto.toEmailMessageDto();
+            return mailSender.generateMessage(senderSession, messageDto);
+        } catch (MessagingException e) {
+            log.error("Error while generating MailSender: " + mailSender + " EmailCreateDto: " + createDto);
+        }
+        return Optional.empty();
+    }
+
+
+    @Transactional(readOnly = false)
+    public Email sendEmail(EmailCreateDto createDto) throws MessagingException {
+        try {
+            // 메일 전송
+            // 1. 메일 정보 조회 & 검증
+            EmailMetadata emailMetadata = emailMetadataService.loadEmailMetadataByEmailAndUserId(createDto.getEmailFrom(), createDto.getUserId());
+
+            if (validMailMetadata(createDto, emailMetadata)) {
+                // 메일 전송 준비
+                MailSender mailSender = generateMailSender(emailMetadata);
+                // 2. 메일 전송
+                Message message = generateMailSenderMessage(mailSender, createDto)
+                        .orElseThrow(() -> new MessagingException("Error while generating MailSender Message:" + createDto));
+                mailSender.sendMessage(message);
+                // 3. 메일 전송 성공 시 Email Entity 저장
+                return emailService.createEmail(createDto);
+            } else
+                throw new IllegalArgumentException("EmailMetadata is not equal to request metadata: " + emailMetadata);
+        } catch (ResourceNotFoundException e) {
+            // 메일 전송 실패 시 rollback & raise error
+            // EmailMetadata 가 존재하지 않으면 rollback
+            log.warn("EmailMetadata not found with createDto: " + createDto);
+            throw e;
+        } catch (MessagingException e) {
+            log.warn("MessagingException: " + e);
+            throw e;
+        }
+    }
+
+    public boolean validMailMetadata(EmailCreateDto createDto, EmailMetadata emailMetadata) {
+        // 요청자 정보와 메일 정보 검증
+        User user = userService.loadUserFromSecurityContextHolder();
+        return emailMetadata.getUser().equals(user);
+    }
 }

--- a/src/main/java/com/example/mailService/email/EmailSendService.java
+++ b/src/main/java/com/example/mailService/email/EmailSendService.java
@@ -1,24 +1,16 @@
 package com.example.mailService.email;
 
 import com.example.mailService.email.dto.EmailCreateDto;
-import com.example.mailService.email.dto.EmailMessageDto;
 import com.example.mailService.email.entity.Email;
-import com.example.mailService.email.entity.EmailMetadata;
-import com.example.mailService.exception.ResourceNotFoundException;
-import com.example.mailService.user.UserService;
-import com.example.mailService.user.entity.User;
 import com.example.mailService.utils.MailSender;
+import com.sun.mail.util.MailConnectException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
 import org.springframework.transaction.annotation.Transactional;
 
-import javax.mail.Message;
 import javax.mail.MessagingException;
-import javax.mail.Session;
-import javax.mail.internet.InternetAddress;
-import java.util.Optional;
-import java.util.Properties;
+
 
 @Slf4j
 @Service
@@ -27,75 +19,35 @@ import java.util.Properties;
 public class EmailSendService {
     // 메일 전송 서비스
 
-    private UserService userService;
+    private final EmailService emailService;
 
-    private EmailService emailService;
+    private final EmailMetadataService emailMetadataService;
 
-    private EmailMetadataService emailMetadataService;
-
-    private MailSender mailSender;
-
-    public MailSender generateMailSender(EmailMetadata metadata) {
-        Properties properties = new Properties();
-        properties.put("mail.smtp.host", metadata.getSmtpHost());
-        properties.put("mail.smtp.port", metadata.getSmtpPort());
-        properties.put("mail.smtp.auth", "true");
-        properties.put("mail.smtp.ssl.enable", "true");
-        properties.put("mail.smtp.trust", metadata.getSmtpHost());
-
-        return MailSender.builder()
-                .username(metadata.getUsername())
-                .password(metadata.getPassword())
-                .smtpHost(metadata.getSmtpHost())
-                .smtpPort(metadata.getSmtpPort())
-                .properties(properties)
-                .build();
-    }
-
-    public Optional<Message> generateMailSenderMessage(MailSender mailSender, EmailCreateDto createDto) {
-        try {
-            Session senderSession = mailSender.generateMailSession();
-            EmailMessageDto messageDto = createDto.toEmailMessageDto();
-            return mailSender.generateMessage(senderSession, messageDto);
-        } catch (MessagingException e) {
-            log.error("Error while generating MailSender: " + mailSender + " EmailCreateDto: " + createDto);
-        }
-        return Optional.empty();
-    }
+    private final MailSender mailSender;
 
 
     @Transactional(readOnly = false)
-    public Email sendEmail(EmailCreateDto createDto) throws MessagingException {
+    public Email sendEmail(EmailCreateDto createDto) {
         try {
             // 메일 전송
             // 1. 메일 정보 조회 & 검증
-            EmailMetadata emailMetadata = emailMetadataService.loadEmailMetadataByEmailAndUserId(createDto.getEmailFrom(), createDto.getUserId());
+            if (emailMetadataService.validMailMetadata(createDto)) {
 
-            if (validMailMetadata(createDto, emailMetadata)) {
-                // 메일 전송 준비
-                MailSender mailSender = generateMailSender(emailMetadata);
                 // 2. 메일 전송
-                Message message = generateMailSenderMessage(mailSender, createDto)
-                        .orElseThrow(() -> new MessagingException("Error while generating MailSender Message:" + createDto));
-                mailSender.sendMessage(message);
-                // 3. 메일 전송 성공 시 Email Entity 저장
+                sendEmailByEmailCreateDto(createDto);
+
+                // 3. 메일 전송 후 Email Entity 저장
                 return emailService.createEmail(createDto);
-            } else
-                throw new IllegalArgumentException("EmailMetadata is not equal to request metadata: " + emailMetadata);
-        } catch (ResourceNotFoundException e) {
-            // 메일 전송 실패 시 rollback & raise error
-            // EmailMetadata 가 존재하지 않으면 rollback
-            log.warn("EmailMetadata not found with createDto: " + createDto);
-            throw e;
+
+            } else throw new IllegalArgumentException("EmailMetadata is not equal to request metadata: " + createDto);
         } catch (MessagingException e) {
-            log.warn("MessagingException: " + e);
-            throw e;
+            log.error("Error while sending Email: " + createDto);
+            e.getStackTrace();
+            throw new RuntimeException(e);
         }
     }
 
-    public boolean validMailMetadata(EmailCreateDto createDto, EmailMetadata emailMetadata) {
-        // 요청자 정보와 메일 정보 검증
-        User user = userService.loadUserFromSecurityContextHolder();
-        return emailMetadata.getUser().equals(user);
+    public void sendEmailByEmailCreateDto(EmailCreateDto createDto) throws MessagingException {
+        mailSender.sendMailByEmailCreateDto(createDto);
     }
 }

--- a/src/main/java/com/example/mailService/email/EmailSendService.java
+++ b/src/main/java/com/example/mailService/email/EmailSendService.java
@@ -3,7 +3,6 @@ package com.example.mailService.email;
 import com.example.mailService.email.dto.EmailCreateDto;
 import com.example.mailService.email.entity.Email;
 import com.example.mailService.utils.MailSender;
-import com.sun.mail.util.MailConnectException;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Service;
@@ -34,7 +33,7 @@ public class EmailSendService {
             if (emailMetadataService.validMailMetadata(createDto)) {
 
                 // 2. 메일 전송
-                sendEmailByEmailCreateDto(createDto);
+                mailSender.sendMailByEmailCreateDto(createDto);
 
                 // 3. 메일 전송 후 Email Entity 저장
                 return emailService.createEmail(createDto);
@@ -45,9 +44,5 @@ public class EmailSendService {
             e.getStackTrace();
             throw new RuntimeException(e);
         }
-    }
-
-    public void sendEmailByEmailCreateDto(EmailCreateDto createDto) throws MessagingException {
-        mailSender.sendMailByEmailCreateDto(createDto);
     }
 }

--- a/src/main/java/com/example/mailService/email/EmailService.java
+++ b/src/main/java/com/example/mailService/email/EmailService.java
@@ -31,6 +31,7 @@ public class EmailService {
         );
     }
 
+    @Transactional(readOnly = false)
     public Email createEmail(EmailCreateDto createDto) {
         User requestUser = userService.loadUserFromSecurityContextHolder();
         if (createDto.getUserId().equals(requestUser.getId())) {
@@ -38,6 +39,7 @@ public class EmailService {
         } else throw new IllegalArgumentException("Request user is not equal. User: " + requestUser.getId() + ", Request:" + createDto.getUserId());
     }
 
+    @Transactional(readOnly = false)
     public void deleteEmail(Long emailId) {
         // 메일은 수정이 존재하지 않음.
         // 조회 / 생성 / 삭제만 존재.

--- a/src/main/java/com/example/mailService/email/dto/EmailCreateDto.java
+++ b/src/main/java/com/example/mailService/email/dto/EmailCreateDto.java
@@ -4,6 +4,9 @@ import com.example.mailService.email.entity.Email;
 import lombok.Builder;
 import lombok.Getter;
 
+import javax.mail.Address;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
 import java.time.LocalDateTime;
 
 @Getter
@@ -24,7 +27,7 @@ public class EmailCreateDto {
 
     private String subject;
 
-    private String content;
+    private String text;
 
     private LocalDateTime dateTimeSend;
 
@@ -39,9 +42,24 @@ public class EmailCreateDto {
                 .emailCcList(emailCcList)
                 .emailBccList(emailBccList)
                 .subject(subject)
-                .content(content)
+                .content(text)
                 .dateTimeSend(dateTimeSend)
                 .dateTimeReceive(dateTimeReceive)
+                .build();
+    }
+
+    public EmailMessageDto toEmailMessageDto() throws MessagingException {
+        Address[] addressesTo = InternetAddress.parse(getEmailToList());
+        Address[] addressesCc = InternetAddress.parse(getEmailCcList());
+        Address[] addressesBcc = InternetAddress.parse(getEmailBccList());
+
+        return EmailMessageDto.builder()
+                .addressFrom(new InternetAddress(getEmailFrom()))
+                .addressTo(addressesTo)
+                .addressCc(addressesCc)
+                .addressBcc(addressesBcc)
+                .subject(getSubject())
+                .text(getText())
                 .build();
     }
 }

--- a/src/main/java/com/example/mailService/email/dto/EmailMessageDto.java
+++ b/src/main/java/com/example/mailService/email/dto/EmailMessageDto.java
@@ -1,0 +1,23 @@
+package com.example.mailService.email.dto;
+
+import lombok.Builder;
+import lombok.Getter;
+
+import javax.mail.Address;
+import javax.mail.MessagingException;
+import javax.mail.internet.InternetAddress;
+
+@Getter
+@Builder
+public class EmailMessageDto {
+
+    private InternetAddress addressFrom;
+
+    private Address[] addressTo;
+    private Address[] addressCc;
+    private Address[] addressBcc;
+
+    private String subject;
+
+    private String text;
+}

--- a/src/main/java/com/example/mailService/repository/EmailMetadataRepository.java
+++ b/src/main/java/com/example/mailService/repository/EmailMetadataRepository.java
@@ -6,7 +6,7 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import java.util.List;
 import java.util.Optional;
 
-public interface UserEmailInfoRepository extends JpaRepository<EmailMetadata, Long> {
+public interface EmailMetadataRepository extends JpaRepository<EmailMetadata, Long> {
 
     // userId 에 속한 모든 메일전송 정보 조회
     List<EmailMetadata> findAllByUser_Id(Long userId);

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,3 +1,7 @@
+authentication:
+  secret-key: rvsf2Zk4adpAJ41rIesA4g==
+  expiration-time: 864000000 # 1 day
+
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/email?serverTimezone=Asia/Seoul
@@ -12,6 +16,6 @@ spring:
     generate-ddl: true
     show-sql: true
 
-authentication:
-  secret-key: rvsf2Zk4adpAJ41rIesA4g==
-  expiration-time: 864000000 # 1 day
+logging:
+  level:
+    org.springframework.transaction: TRACE

--- a/src/test/java/com/example/mailService/base/BaseTestSetup.java
+++ b/src/test/java/com/example/mailService/base/BaseTestSetup.java
@@ -18,6 +18,8 @@ public abstract class BaseTestSetup {
 
     protected User testUser;
 
+    protected User compareUser;
+
     @BeforeEach
     protected void beforeEach() {
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
@@ -29,5 +31,20 @@ public abstract class BaseTestSetup {
                 .role(UserRole.ROLE_USER)
                 .build();
         userRepository.save(testUser);
+    }
+
+    /**
+     * 인증/인가 및 리소스 소유자 검사용 유저 테스트데이터
+     */
+    protected void createCompareUser() {
+        BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
+
+        compareUser = User.builder()
+                .username("compareUser")
+                .email("compareUser@test.com")
+                .password(passwordEncoder.encode(PASSWORD))
+                .role(UserRole.ROLE_USER)
+                .build();
+        userRepository.save(compareUser);
     }
 }

--- a/src/test/java/com/example/mailService/base/BaseTestSetup.java
+++ b/src/test/java/com/example/mailService/base/BaseTestSetup.java
@@ -19,7 +19,7 @@ public abstract class BaseTestSetup {
     protected User testUser;
 
     @BeforeEach
-    void beforeEach() {
+    protected void beforeEach() {
         BCryptPasswordEncoder passwordEncoder = new BCryptPasswordEncoder();
 
         testUser = User.builder()

--- a/src/test/java/com/example/mailService/controller/AuthControllerTest.java
+++ b/src/test/java/com/example/mailService/controller/AuthControllerTest.java
@@ -18,8 +18,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 class AuthControllerTest extends BaseTestSetup {
 
+    private final AuthController authController;
+
     @Autowired
-    private AuthController authController;
+    public AuthControllerTest(AuthController authController) {
+        this.authController = authController;
+    }
 
     private UserLoginDto testUserLoginDto() {
         return UserLoginDto.builder()

--- a/src/test/java/com/example/mailService/controller/UserControllerTest.java
+++ b/src/test/java/com/example/mailService/controller/UserControllerTest.java
@@ -14,8 +14,12 @@ import org.springframework.transaction.annotation.Transactional;
 @Transactional
 class UserControllerTest extends BaseTestSetup {
 
+    private final UserController userController;
+
     @Autowired
-    private UserController userController;
+    public UserControllerTest(UserController userController) {
+        this.userController = userController;
+    }
 
     @Test
     @WithMockUser(username = USERNAME, password = PASSWORD)

--- a/src/test/java/com/example/mailService/email/EmailMetadataServiceTest.java
+++ b/src/test/java/com/example/mailService/email/EmailMetadataServiceTest.java
@@ -40,8 +40,8 @@ class EmailMetadataServiceTest extends BaseTestSetup {
         MailMetadataCreateDto createDto = createTestDto("test@testEmail.com", testUser);
 
         // when
-        EmailMetadata emailMetadata = emailMetadataService.createUserEmailInfo(createDto);
-        EmailMetadata retrieveEmailMetadata = emailMetadataService.loadUserEmailInfoById(emailMetadata.getId());
+        EmailMetadata emailMetadata = emailMetadataService.createEmailMetadata(createDto);
+        EmailMetadata retrieveEmailMetadata = emailMetadataService.loadEmailMetadataById(emailMetadata.getId());
 
         // then
         Assertions.assertThat(emailMetadata.getEmail()).isEqualTo("test@testEmail.com");
@@ -59,11 +59,11 @@ class EmailMetadataServiceTest extends BaseTestSetup {
         MailMetadataCreateDto createDto2 = createTestDto("test2@testEmail.com", testUser);
 
         // when
-        EmailMetadata emailMetadata1 = emailMetadataService.createUserEmailInfo(createDto1);
-        EmailMetadata emailMetadata2 = emailMetadataService.createUserEmailInfo(createDto2);
+        EmailMetadata emailMetadata1 = emailMetadataService.createEmailMetadata(createDto1);
+        EmailMetadata emailMetadata2 = emailMetadataService.createEmailMetadata(createDto2);
 
         // then
-        List<EmailMetadata> emailInfoList = emailMetadataService.loadUserEmailInfoListByUserId(testUser.getId());
+        List<EmailMetadata> emailInfoList = emailMetadataService.loadEmailMetadataListByUserId(testUser.getId());
 
         Assertions.assertThat(emailInfoList).isEqualTo(Arrays.asList(emailMetadata1, emailMetadata2));
     }
@@ -80,7 +80,7 @@ class EmailMetadataServiceTest extends BaseTestSetup {
         // when
 
         // then
-        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> emailMetadataService.createUserEmailInfo(wrongCreateDto));
+        org.junit.jupiter.api.Assertions.assertThrows(IllegalArgumentException.class, () -> emailMetadataService.createEmailMetadata(wrongCreateDto));
     }
 
     @Test
@@ -89,9 +89,9 @@ class EmailMetadataServiceTest extends BaseTestSetup {
         // given
         MailMetadataCreateDto duplicateCreateDto = createTestDto("test@testEmail.com", testUser);
         // when
-        EmailMetadata emailMetadata = emailMetadataService.createUserEmailInfo(duplicateCreateDto);
+        EmailMetadata emailMetadata = emailMetadataService.createEmailMetadata(duplicateCreateDto);
 
         // then
-        org.junit.jupiter.api.Assertions.assertThrows(ResourceAlreadyExistException.class, () -> emailMetadataService.createUserEmailInfo(duplicateCreateDto));
+        org.junit.jupiter.api.Assertions.assertThrows(ResourceAlreadyExistException.class, () -> emailMetadataService.createEmailMetadata(duplicateCreateDto));
     }
 }

--- a/src/test/java/com/example/mailService/email/EmailMetadataServiceTest.java
+++ b/src/test/java/com/example/mailService/email/EmailMetadataServiceTest.java
@@ -5,6 +5,7 @@ import com.example.mailService.email.dto.MailMetadataCreateDto;
 import com.example.mailService.user.entity.User;
 import com.example.mailService.email.entity.EmailMetadata;
 import com.example.mailService.exception.ResourceAlreadyExistException;
+import lombok.RequiredArgsConstructor;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -19,8 +20,13 @@ import java.util.List;
 @Transactional
 class EmailMetadataServiceTest extends BaseTestSetup {
 
+//    @Autowired
+    private final EmailMetadataService emailMetadataService;
+
     @Autowired
-    private EmailMetadataService emailMetadataService;
+    public EmailMetadataServiceTest(EmailMetadataService emailMetadataService) {
+        this.emailMetadataService = emailMetadataService;
+    }
 
     private MailMetadataCreateDto createTestDto(String email, User user) {
         return MailMetadataCreateDto.builder()

--- a/src/test/java/com/example/mailService/email/EmailSendServiceTest.java
+++ b/src/test/java/com/example/mailService/email/EmailSendServiceTest.java
@@ -1,0 +1,104 @@
+package com.example.mailService.email;
+
+import com.example.mailService.base.BaseTestSetup;
+import com.example.mailService.email.dto.EmailCreateDto;
+import com.example.mailService.email.entity.Email;
+import com.example.mailService.email.entity.EmailMetadata;
+import com.example.mailService.repository.EmailMetadataRepository;
+import com.example.mailService.utils.MailSender;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.boot.test.mock.mockito.SpyBean;
+import org.springframework.security.test.context.support.WithMockUser;
+import org.springframework.transaction.annotation.Transactional;
+
+import javax.mail.Message;
+
+import static org.assertj.core.api.Assertions.*;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.Mockito.*;
+
+@Transactional
+@ExtendWith(MockitoExtension.class)
+@SpringBootTest
+class EmailSendServiceTest extends BaseTestSetup {
+
+    @InjectMocks
+    private EmailSendService emailSendService;
+
+    @SpyBean
+    private MailSender mailSender;
+
+    private final EmailService emailService;
+
+    private final EmailMetadataRepository metadataRepository;
+
+
+    @Autowired
+    public EmailSendServiceTest(EmailSendService emailSendService, MailSender mailSender, EmailService emailService, EmailMetadataRepository metadataRepository) {
+        this.emailSendService = emailSendService;
+        this.mailSender = mailSender;
+        this.emailService = emailService;
+        this.metadataRepository = metadataRepository;
+    }
+
+    // 시나리오
+    // 사용자: testUser from BaseTestSetup
+    // 데이터: 메일 정보 (beforeEach) & 메시지 (메소드로 제공)
+    // 1. 메시지 생성 -> mock 적용
+
+
+    @BeforeEach
+    protected void beforeEach() {
+        super.beforeEach();
+        EmailMetadata metadata = metadataRepository.save(
+                EmailMetadata.builder()
+                        .email("testUser@testMail.com")
+                        .username("testUser")
+                        .password("testPassword")
+                        .smtpHost("smtp.testMail.com")
+                        .smtpPort(465L)
+                        .user(testUser)
+                        .build()
+        );
+    }
+
+    private EmailCreateDto testEmailCreateDto() {
+        return EmailCreateDto.builder()
+                .emailFrom("testUser@testMail.com")
+                .emailTo("to@otherMail.com")
+                .subject("This is Test mail")
+                .text("test mail text")
+                .userId(testUser.getId())
+                .emailToList("to@otherMail.com")
+                .emailCcList("cc1@otherMail.com, cc2@otherMail.com")
+                .emailBccList("bcc1@otherMail.com, bcc2@otherMail.com")
+                .build();
+    }
+
+    @Test
+    @WithMockUser(username = USERNAME, password = PASSWORD)
+    public void EmailSendService__sendEmail() throws Exception {
+        // given
+        // MailSender.sendMessage 는 mock 처리 (doNothing)
+        // MailSender.sendMailByEmailCreateDto 를 포함한 그 외는 정상처리 (SpyBean)
+        doNothing().when(mailSender).sendMessage(any(Message.class));
+        doCallRealMethod().when(mailSender).sendMessage(any(Message.class));
+
+        // when
+        Email email = emailSendService.sendEmail(testEmailCreateDto());
+
+        // then
+        Email loadEmailById = emailService.loadEmailById(email.getId());
+
+        assertThat(email).isEqualTo(loadEmailById);
+    }
+
+}

--- a/src/test/java/com/example/mailService/email/EmailSendServiceTest.java
+++ b/src/test/java/com/example/mailService/email/EmailSendServiceTest.java
@@ -90,7 +90,6 @@ class EmailSendServiceTest extends BaseTestSetup {
         // MailSender.sendMessage 는 mock 처리 (doNothing)
         // MailSender.sendMailByEmailCreateDto 를 포함한 그 외는 정상처리 (SpyBean)
         doNothing().when(mailSender).sendMessage(any(Message.class));
-        doCallRealMethod().when(mailSender).sendMessage(any(Message.class));
 
         // when
         Email email = emailSendService.sendEmail(testEmailCreateDto());

--- a/src/test/java/com/example/mailService/email/EmailServiceTest.java
+++ b/src/test/java/com/example/mailService/email/EmailServiceTest.java
@@ -19,8 +19,12 @@ import java.util.List;
 @Transactional
 class EmailServiceTest extends BaseTestSetup {
 
+    private final EmailService emailService;
+
     @Autowired
-    private EmailService emailService;
+    public EmailServiceTest(EmailService emailService) {
+        this.emailService = emailService;
+    }
 
     @Test
     @WithMockUser(username = USERNAME, password = PASSWORD)

--- a/src/test/java/com/example/mailService/user/AuthServiceTest.java
+++ b/src/test/java/com/example/mailService/user/AuthServiceTest.java
@@ -21,12 +21,12 @@ import static org.junit.jupiter.api.Assertions.*;
 @Transactional
 class AuthServiceTest extends BaseTestSetup {
 
-    @Autowired
-    private AuthService authService;
+    private final AuthService authService;
 
     @Autowired
-    private UserService userService;
-
+    public AuthServiceTest(AuthService authService) {
+        this.authService = authService;
+    }
 
     private UserLoginDto testUserLoginDto() {
         return UserLoginDto.builder()

--- a/src/test/java/com/example/mailService/user/UserServiceTest.java
+++ b/src/test/java/com/example/mailService/user/UserServiceTest.java
@@ -15,8 +15,12 @@ import javax.transaction.Transactional;
 @Transactional
 class UserServiceTest extends BaseTestSetup {
 
+    private final UserService userService;
+
     @Autowired
-    private UserService userService;
+    public UserServiceTest(UserService userService) {
+        this.userService = userService;
+    }
 
     @Test
     public void UserService_loadUserByEmail() throws Exception {

--- a/target/classes/application.yml
+++ b/target/classes/application.yml
@@ -1,3 +1,7 @@
+authentication:
+  secret-key: rvsf2Zk4adpAJ41rIesA4g==
+  expiration-time: 864000000 # 1 day
+
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/email?serverTimezone=Asia/Seoul
@@ -12,6 +16,6 @@ spring:
     generate-ddl: true
     show-sql: true
 
-authentication:
-  secret-key: rvsf2Zk4adpAJ41rIesA4g==
-  expiration-time: 864000000 # 1 day
+logging:
+  level:
+    org.springframework.transaction: TRACE


### PR DESCRIPTION
Issue #21 

- 메일 전송 과정
    - 요청한 메일전송 정보와 요청자의 정보 유효성 검증 (EmailMetadata)
    - Java Mail API 호출을 통해 메일 전송
    - EmailService 로 전송한 메일정보 저장

---

EmailMetadataService : 이메일 전송정보(유저 / SMTP 정보) 관리
MailSender : Java Mail API 를 사용해 메일 전송이 이뤄지는 util
EmailService : 메일정보 저장 & 관리
EmailSendService : 메일 전송을 위해 접근하는 서비스로 EmailMetadataService, MailSender, EmailService 에 의존성을 가짐

---

테스트케이스

- 전체 application level 테스트케이스의 DI를 constructor injection 으로 수정

https://github.com/wiggleji/mailService/blob/b68aa2fe1c99e20e9e3af7f5d4daa588be053fa6/src/test/java/com/example/mailService/email/EmailSendServiceTest.java#L27-L128

- 메일 전송 테스트케이스
    공통: MailSender.sendMessage 는 mocking 처리
    - 메일 전송 후 메일 생성 여부 확인
    - 유효하지 않은 요청 검증
        - 존재하지 않는 EmailMetadata
        - 일치하지 않는 EmailMetadata