### PR TITLE
Encryption 모듈 수정

### DIFF
--- a/src/main/java/com/example/mailService/SpringContext.java
+++ b/src/main/java/com/example/mailService/SpringContext.java
@@ -1,0 +1,23 @@
+package com.example.mailService;
+
+import org.springframework.beans.BeansException;
+import org.springframework.context.ApplicationContext;
+import org.springframework.context.ApplicationContextAware;
+import org.springframework.stereotype.Component;
+
+@Component
+public class SpringContext implements ApplicationContextAware {
+
+    private static ApplicationContext context;
+
+    public static <T extends Object> T getBean(Class<T> beanClass) {
+        return context.getBean(beanClass);
+    }
+
+    @Override
+    public void setApplicationContext(ApplicationContext context) throws BeansException {
+
+        // store ApplicationContext reference to access required beans later on
+        SpringContext.context = context;
+    }
+}

--- a/src/main/java/com/example/mailService/email/dto/EmailMetadataCreateDto.java
+++ b/src/main/java/com/example/mailService/email/dto/EmailMetadataCreateDto.java
@@ -3,10 +3,9 @@ package com.example.mailService.email.dto;
 import com.example.mailService.user.entity.User;
 import com.example.mailService.email.entity.EmailMetadata;
 import com.example.mailService.utils.Encryption;
+import com.example.mailService.SpringContext;
 import lombok.Builder;
 import lombok.Getter;
-import org.springframework.security.crypto.bcrypt.BCryptPasswordEncoder;
-import org.springframework.security.crypto.password.PasswordEncoder;
 
 @Getter
 @Builder
@@ -23,10 +22,12 @@ public class EmailMetadataCreateDto {
     private Long smtpPort;
 
     public EmailMetadata toEntity(User user) {
+        Encryption encryption = SpringContext.getBean(Encryption.class);
+
         return EmailMetadata.builder()
                 .email(email)
                 .username(username)
-                .password(Encryption.encryptAES256(password))
+                .password(encryption.encryptAES256(password))
                 .smtpHost(smtpHost)
                 .smtpPort(smtpPort)
                 .user(user)

--- a/src/main/java/com/example/mailService/email/entity/EmailMetadata.java
+++ b/src/main/java/com/example/mailService/email/entity/EmailMetadata.java
@@ -4,8 +4,8 @@ import com.example.mailService.email.dto.EmailMetadataUpdateDto;
 import com.example.mailService.user.entity.BaseEntity;
 import com.example.mailService.user.entity.User;
 import com.example.mailService.utils.Encryption;
+import com.example.mailService.SpringContext;
 import lombok.*;
-import org.springframework.beans.factory.annotation.Autowired;
 
 import javax.persistence.*;
 
@@ -44,9 +44,11 @@ public class EmailMetadata extends BaseEntity {
     private User user;
 
     public void update(EmailMetadataUpdateDto updateDto) {
+        Encryption encryption = SpringContext.getBean(Encryption.class);
+
         this.email = updateDto.getEmail();
         this.username = updateDto.getUsername();
-        this.password = Encryption.encryptAES256(updateDto.getPassword());
+        this.password = encryption.encryptAES256(updateDto.getPassword());
         this.smtpHost = updateDto.getSmtpHost();
         this.smtpPort = updateDto.getSmtpPort();
     }

--- a/src/main/java/com/example/mailService/utils/Encryption.java
+++ b/src/main/java/com/example/mailService/utils/Encryption.java
@@ -1,7 +1,11 @@
 package com.example.mailService.utils;
 
-import lombok.experimental.UtilityClass;
+import lombok.AllArgsConstructor;
+import lombok.NoArgsConstructor;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.stereotype.Component;
 
 import javax.crypto.Cipher;
 import javax.crypto.spec.SecretKeySpec;
@@ -9,18 +13,22 @@ import java.nio.charset.StandardCharsets;
 import java.util.Base64;
 
 @Slf4j
-@UtilityClass
+@NoArgsConstructor
+@AllArgsConstructor
+@Component
 public class Encryption {
 
-    private final static String secretKey = "RB15AW0JUI7ZL8BX";
-    public static String ALGORITHM = "AES";
+    @Value("${encryption.secret-key}")
+    private String secretKey;
+    private String ALGORITHM = "AES";
 
-    private static final String encryptedSalt = "AES/" + secretKey.substring(0,4) + "/";
-
+    private String getEncryptedSalt() {
+        return "AES/" + secretKey.substring(0,4) + "/";
+    }
 
     public String encryptAES256(String text) {
         try {
-            if (text.startsWith(encryptedSalt)) {
+            if (text.startsWith(getEncryptedSalt())) {
                 // 암호화된 데이터는 그대로 반환
                 return text;
             } else {
@@ -30,7 +38,7 @@ public class Encryption {
                 cipher.init(Cipher.ENCRYPT_MODE, secretKeySpec);
 
                 byte[] encrypted = cipher.doFinal(text.getBytes(StandardCharsets.UTF_8));
-                return encryptedSalt + Base64.getEncoder().withoutPadding().encodeToString(encrypted);
+                return getEncryptedSalt() + Base64.getEncoder().withoutPadding().encodeToString(encrypted);
 
             }
         } catch (Exception e) {
@@ -41,7 +49,7 @@ public class Encryption {
 
     public String decryptAES256(String cipherTextWithSalt) {
         try {
-            if (cipherTextWithSalt.startsWith(encryptedSalt)) {
+            if (cipherTextWithSalt.startsWith(getEncryptedSalt())) {
                 String cipherText = cipherTextWithSalt.substring(
                         cipherTextWithSalt.lastIndexOf("/") + 1);
                 Cipher cipher = Cipher.getInstance(ALGORITHM);

--- a/src/main/java/com/example/mailService/utils/MailSender.java
+++ b/src/main/java/com/example/mailService/utils/MailSender.java
@@ -24,13 +24,15 @@ public class MailSender {
 
     private final EmailMetadataService metadataService;
 
+    private final Encryption encryption;
+
     public Session generateMailSession(EmailMetadata metadata) {
         // 메일 전송을 위한 메일세션 생성
         Properties properties = metadataService.generateEmailMetadataProperty(metadata);
         return Session.getDefaultInstance(properties, new Authenticator() {
             @Override
             protected PasswordAuthentication getPasswordAuthentication() {
-                return new PasswordAuthentication(metadata.getUsername(), Encryption.decryptAES256(metadata.getPassword()));
+                return new PasswordAuthentication(metadata.getUsername(), encryption.decryptAES256(metadata.getPassword()));
             }
         });
     }

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -2,6 +2,9 @@ authentication:
   secret-key: rvsf2Zk4adpAJ41rIesA4g==
   expiration-time: 864000000 # 1 day
 
+encryption:
+  secret-key: RB15AW0JUI7ZL8BX
+
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/email?serverTimezone=Asia/Seoul

--- a/src/test/java/com/example/mailService/utils/EncryptionTest.java
+++ b/src/test/java/com/example/mailService/utils/EncryptionTest.java
@@ -2,19 +2,28 @@ package com.example.mailService.utils;
 
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.junit.jupiter.api.Assertions.*;
 
+@SpringBootTest
 class EncryptionTest {
+    private final Encryption encryption;
+
+    @Autowired
+    public EncryptionTest(Encryption encryption) {
+        this.encryption = encryption;
+    }
+
     @Test
     public void Encryption__encryptAES256_plainText() throws Exception {
         // given
         final String validateText = "testText";
 
         // when
-        String encryptAES256 = Encryption.encryptAES256(validateText);
+        String encryptAES256 = encryption.encryptAES256(validateText);
 
         // then
         assertThat(encryptAES256).startsWith("AES");
@@ -26,8 +35,8 @@ class EncryptionTest {
         final String validateText = "testText";
 
         // when
-        String encryptAES256 = Encryption.encryptAES256(validateText);
-        String plainText = Encryption.decryptAES256(encryptAES256);
+        String encryptAES256 = encryption.encryptAES256(validateText);
+        String plainText = encryption.decryptAES256(encryptAES256);
 
         // then
         assertThat(plainText).isEqualTo(validateText);

--- a/target/classes/application.yml
+++ b/target/classes/application.yml
@@ -2,6 +2,9 @@ authentication:
   secret-key: rvsf2Zk4adpAJ41rIesA4g==
   expiration-time: 864000000 # 1 day
 
+encryption:
+  secret-key: RB15AW0JUI7ZL8BX
+
 spring:
   datasource:
     url: jdbc:mysql://localhost:3306/email?serverTimezone=Asia/Seoul


### PR DESCRIPTION
- AS-IS

Encryption 클래스를 lombok UtilityClass로 지정하여 정적 클래스로 사용
파라미터 또한 정적으로 사용해야 하기에 암호키를 application 프로퍼티에서 불러올 수 없음

- 작업내용

Encryption 클래스를 bean으로 등록
DTO에서 쓰일 경우, bean을 읽어와 암/복호화 진행하도록
application context 에서 bean을 읽어들일 수 있는 SpringContext 클래스 추가